### PR TITLE
Improve executable compression

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,10 +37,6 @@ jobs:
       - name: Check out
         uses: actions/checkout@v2
 
-      - name: Install upx on macOS
-        if: matrix.os_name == 'macos'
-        run: brew install upx
-
       - name: Cache ~/.stack folder
         uses: actions/cache@v2
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,12 +7,10 @@ name: Create Release
 
 jobs:
   create_release:
-    name: Create Release
     runs-on: ubuntu-latest
     outputs:
-      upload_url: ${{ steps.step_upload_url.outputs.upload_url }}
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v2
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -23,18 +21,50 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: true
           prerelease: false
-      - id: step_upload_url
-        run: echo "::set-output name=upload_url::${{ steps.create_release.outputs.upload_url }}"
 
   build:
-    needs: [create_release]
+    needs: create_release
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        include:
+        - os: ubuntu-latest
+          os_name: linux
+        - os: macos-latest
+          os_name: macos
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Install upx on macOS
+        if: matrix.os_name == 'macos'
+        run: brew install upx
+
+      - name: Cache ~/.stack folder
+        uses: actions/cache@v2
+        with:
+          path: ~/.stack
+          key: stack-global-${{hashFiles('**.yaml')}}
+          restore-keys: |
+            stack-global
+
+      - name: Cache ~/.local/bin folder
+        uses: actions/cache@v2
+        with:
+          path: ~/.local/bin
+          key: stack-local-bin-${{hashFiles('**.yaml')}}
+          restore-keys: |
+            stack-local-bin
+
+      - name: Cache .stack-work folder
+        uses: actions/cache@v2
+        with:
+          path: .stack-work
+          key: stack-work-${{hashFiles('**.yaml')}}
+          restore-keys: |
+            stack-work
+
       - uses: haskell/actions/setup@v1
         with:
           ghc-version: '8.8.4' # Exact version of ghc to use
@@ -42,11 +72,14 @@ jobs:
           stack-version: 'latest'
 
       - name: Build project
-        id: build_project
+        run: stack install --test
+
+      - name: Compress executable
         run: |
-          stack build --test
-          export STACK_PATH=$(stack path --local-install-root)
-          echo ::set-output name=ARTIFACT_PATH::$STACK_PATH/bin/thock
+          mv ~/.local/bin/thock .
+          strip thock
+          upx -9 thock
+          tar czf thock.tar.gz thock
 
       - name: Upload Release Asset
         id: upload-release-asset 
@@ -55,6 +88,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.build_project.outputs.ARTIFACT_PATH }}
-          asset_name: thock-${{ runner.os }}
-          asset_content_type: application/octet-stream
+          asset_path: thock.tar.gz
+          asset_name: thock-${{ matrix.os_name }}.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,14 +72,18 @@ jobs:
           stack-version: 'latest'
 
       - name: Build project
-        run: stack install --test
+        run: |
+          stack install --test
+          mv ~/.local/bin/thock .
+
+      - name: Reduce size of executable
+        uses: svenstaro/upx-action@v2
+        with:
+          file: thock
+          args: "-9"
 
       - name: Compress executable
-        run: |
-          mv ~/.local/bin/thock .
-          strip thock
-          upx -9 thock
-          tar czf thock.tar.gz thock
+        run: tar czf thock.tar.gz thock
 
       - name: Upload Release Asset
         id: upload-release-asset 

--- a/package.yaml
+++ b/package.yaml
@@ -47,6 +47,7 @@ executables:
     main:                Main.hs
     source-dirs:         app
     ghc-options:
+    - -O3
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N

--- a/thock.cabal
+++ b/thock.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3578940c332c49e044c3fc970683e95f1998817ba1184134bb9347284b4e1dfd
+-- hash: c91f36bf4b2fe28229da48414108d1915a433f3822f21b361911bb87e49a9e5c
 
 name:           thock
 version:        0.1.0.0
@@ -97,7 +97,7 @@ executable thock
   hs-source-dirs:
       app
   default-extensions: OverloadedStrings
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
+  ghc-options: -O3 -threaded -rtsopts -with-rtsopts=-N -Wall
   build-depends:
       aeson
     , base >=4.7 && <5


### PR DESCRIPTION
I reduced the executable size (thanks to @dpwiz [#1](https://github.com/rmehri01/thock/issues/1#issue-776865046)), but I wasn't able to make the `-split-sections` GHC option work on macOS so I discarded it (see https://github.com/soywod/thock/runs/1631930101). I zipped the result to gain even more space at download time. The size is reduced by 5:

![image](https://user-images.githubusercontent.com/10437171/103431504-1e16f080-4bd1-11eb-8931-870c6f742874.png)

I also added some cache to reduce the build time.